### PR TITLE
Fix broken navigation + optimization

### DIFF
--- a/miner.lua
+++ b/miner.lua
@@ -298,6 +298,9 @@ calibration = function() -- калибровка при запуске
 end
 
 inv_check = function() -- инвентаризация
+  if ignore_check then
+    return
+  end
   local items = 0
   for slot = 1, inventory do
     if robot.count(slot) > 0 then
@@ -420,8 +423,9 @@ sorter = function(pack) -- сортировка лута
 end
 
 home = function(forcibly, interrupt) -- переход к начальной точке и сброс лута
-  local x, y, z
+  local x, y, z, d
   report('ore unloading')
+  ignore_check = true
   local enderchest -- обнулить слот с эндерсундуком
   for slot = 1, inventory do -- просканировать инвентарь
     local item = controller.getStackInInternalSlot(slot) -- получить информацию о слоте
@@ -438,7 +442,7 @@ home = function(forcibly, interrupt) -- переход к начальной т�
     robot.select(enderchest) -- выбрать сундук
     robot.place(3) -- поставить сундук
   else
-    x, y, z = X, Y, Z
+    x, y, z, d = X, Y, Z, D
     go(0, -2, 0)
     go(0, 0, 0)
   end
@@ -574,6 +578,7 @@ home = function(forcibly, interrupt) -- переход к начальной т�
     report('return to work')
     go(0, -2, 0)
     go(x, y, z)
+    smart_turn(d)
   end
 end
 


### PR DESCRIPTION
Суть проблемы с навигацией: если в пути робот понимает, что ему пора домой, он уходит и возвращается, при этом может после этого смотреть не в ту же сторону, что раньше, из-за чего условие прекращения пути вперед никогда не выполняется и робот уходит на бесконечность.
Суть еще проблемы - на пути домой home перед выгрузкой зовет sorter, который зовет inv_check, который зовет home, если все еще нужно домой, и на этом циклится в рекурсии.
Помимо этого inv_check не сеттит игнорирование проверок перед вызовом home, из-за этого на пути домой робот понимает, что ему пора домой, возвращается домой, возвращается обратно, а потом продолжает путь домой. Добавление игнорирования проверок в home и проверку его в inv_check исправляет эти две проблемы.

P.S.
Исправления кодил на сервере на роботе, и вытащить их оттуда адекватным образом не предоставляется возможным, поэтому я их воспроизвел вовне. Но эти изменения я не тестил, поэтому могут быть опечатки или нечто подобное. Стоит проверить (может, сам успею).